### PR TITLE
Move blocked + pulls to follow team activity

### DIFF
--- a/devdigest.rb
+++ b/devdigest.rb
@@ -106,22 +106,6 @@ class Devdigest
       },
     }
 
-    if blocked_issues.empty?
-      add("## No Blocked Issues!")
-    else
-      add("## Blocked Issues")
-      blocked_issues.each {|blocked_issue| add(blocked_issue)}
-      add("")
-    end
-
-    if pull_requests.empty?
-      add("## No Pull Requests!")
-    else
-      add("## Pull Requests")
-      pull_requests.each {|pull_request| add(pull_request)}
-      add("")
-    end
-
     # the events above are in order of priority
     order = important_events.keys
 
@@ -153,6 +137,22 @@ class Devdigest
         end
       end
 
+      add("")
+    end
+
+    if blocked_issues.empty?
+      add("## No Blocked Issues!")
+    else
+      add("## Blocked Issues")
+      blocked_issues.each {|blocked_issue| add(blocked_issue)}
+      add("")
+    end
+
+    if pull_requests.empty?
+      add("## No Pull Requests!")
+    else
+      add("## Pull Requests")
+      pull_requests.each {|pull_request| add(pull_request)}
       add("")
     end
   end


### PR DESCRIPTION
I'd rather see what the team is working on than a long list of pull requests that are mostly invariant and which I can easily get by visiting https://github.com/heroku/api/pulls. Thoughts on making this switch (or even removing the list)? Blocked issues may be a bit more important, but again, I suspect that this will be mostly invariant day-to-day.

/cc @pedro
