### PR TITLE
Adds support for passing usernames into rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,11 @@ require './lib/devdigest'
 require './lib/dd/gh'
 
 desc "Run the digest and print to stdout"
-task :digest do
+task :digest, :users do |t, args|
   since = Time.now-24*60*60
-  puts Devdigest.new(since).run
+  opts = {}
+  opts.merge!(args)
+  puts Devdigest.new(since, opts).run
 end
 
 desc "Run weekly ops and print to stdout"

--- a/lib/dd/gh.rb
+++ b/lib/dd/gh.rb
@@ -1,6 +1,6 @@
 module Dd
   class Gh
-    def initialize(token, org, since)
+    def initialize(token, org, since, options)
 
       @org = org
 
@@ -8,6 +8,7 @@ module Dd
 
       @digest = ""
       @since = since
+      @opts = options
     end
 
     def run
@@ -25,7 +26,7 @@ module Dd
       add ""
 
       repos = get_repos(ENV['GITHUB_REPOS'], org)
-      users = get_users(ENV['GITHUB_USERS'], org)
+      users = get_users(@opts[:users] || ENV['GITHUB_USERS'], org)
 
       activity = {}
 
@@ -131,7 +132,7 @@ module Dd
 
     def get_users(users, org)
       if users
-        users = users.split(",")
+        users = users.split(/[ ,]/)
       else
         users = []
         @github.orgs.members.list(org) { |member|

--- a/lib/devdigest.rb
+++ b/lib/devdigest.rb
@@ -3,6 +3,7 @@ class Devdigest
     @since  = since
     @digest = ""
     @only   = options[:only]
+    @opts = options
   end
 
   def run
@@ -25,7 +26,7 @@ class Devdigest
     return if skip?("github")
 
     ENV['GITHUB_ORG'].split(',').sort.each { |org|
-      gh_worker = Dd::Gh.new(ENV['GITHUB_TOKEN'], org, @since)
+      gh_worker = Dd::Gh.new(ENV['GITHUB_TOKEN'], org, @since, @opts)
       gh_digest = gh_worker.run
       add(gh_digest)
     }


### PR DESCRIPTION
Now you can pass usernames into the digest task. I did this because I often pair
and want to see what my pair and I have completed in the digest. But I also
often switch pairs, so editing the .env file every day can be cumbersome.

Now you can run it like this:
`foreman run bundle exec rake digest["justinxreese marktfrey"]`

If you're using zsh like I do, you have to escape brackets in args :/
`foreman run bundle exec rake digest\["justinxreese"\]`

Unfortunately, it looks like commas break rake arguments so the params have to
be separated by spaces.
