### PR TITLE
Fixing bug with username set to nil

### DIFF
--- a/lib/dd/gh.rb
+++ b/lib/dd/gh.rb
@@ -124,7 +124,7 @@ module Dd
 
       activity.keys.sort.each do |user|
         info = @github.users.get user: user
-        if info.has_key?('name') && !info.name.empty?
+        if info.has_key?('name') && !info.name == nil && !info.name.empty?
           add " - **#{info.name}**"
         else
           add " - **#{info.login}**"


### PR DESCRIPTION
Some of our users are having their github username attribute come through as nil, which is causing the rake task to blow up. 

CC: @geemus 
